### PR TITLE
Stop using AnyView

### DIFF
--- a/Sources/ParallaxSwiftUI/ParallaxSwiftUI.swift
+++ b/Sources/ParallaxSwiftUI/ParallaxSwiftUI.swift
@@ -3,14 +3,14 @@ import SwiftUI
 extension View {
     public func parallax(amount: CGFloat = 10, direction: ParallaxDirection = .both) -> some View {
         ParallaxView(
-            view: AnyView(self),
+            view: self,
             amount: amount,
             direction: direction
         )
     }
     public func parallax(minHorizontal: CGFloat = -10, maxHorizontal: CGFloat = 10, minVertical: CGFloat = -10, maxVertical: CGFloat = 10, direction: ParallaxDirection = .both) -> some View {
         ParallaxView(
-            view: AnyView(self),
+            view: self,
             minHorizontal: minHorizontal,
             maxHorizontal: maxHorizontal,
             minVertical: minVertical,
@@ -27,11 +27,11 @@ public enum ParallaxDirection {
 }
 
 /// A wrapper view to add a parallax effect to a SwiftUI view.
-struct ParallaxView: View {
-    
+struct ParallaxView<Content: View>: View {
+
     /// The view to apply the parallax too.
-    let view: AnyView
-    
+    let view: Content
+
     /// The amount of the parallax effect to be applied.
     let amount: CGFloat?
     
@@ -43,7 +43,7 @@ struct ParallaxView: View {
     
     let direction: ParallaxDirection
     
-    init(view: AnyView, minHorizontal: CGFloat = -10, maxHorizontal: CGFloat = 10, minVertical: CGFloat = -10, maxVertical: CGFloat = 10, amount: CGFloat? = nil, direction: ParallaxDirection) {
+    init(view: Content, minHorizontal: CGFloat = -10, maxHorizontal: CGFloat = 10, minVertical: CGFloat = -10, maxVertical: CGFloat = 10, amount: CGFloat? = nil, direction: ParallaxDirection) {
         self.view = view
         self.direction = direction
         
@@ -71,9 +71,9 @@ struct ParallaxView: View {
 }
 
 /// Converts SwiftUI view to UIKit controller.
-struct ParallaxRepresentable: UIViewControllerRepresentable {
-    
-    let view: AnyView
+struct ParallaxRepresentable<Content: View>: UIViewControllerRepresentable {
+
+    let view: Content
     let width: CGFloat
     let height: CGFloat
     


### PR DESCRIPTION
A couple of generics that mean we don't need to use AnyView, which could improve performance since view type information is no longer erased.

By the way, I was poking at this more to figure out how it worked, and your solution is super clever. I was trying to do it the other way around: get the `UIInterpolatingMotionEffect` to write to a property in UIKit, then exfiltrate the value of that property up to SwiftUI. But yours works the other way around: it wraps a SwiftUI view in a UIView and then applies the motion effects to the wrapper. I dig it!